### PR TITLE
Implement drag and drop logic for FormBuilder

### DIFF
--- a/components/builder/Designer.tsx
+++ b/components/builder/Designer.tsx
@@ -14,6 +14,7 @@ function Designer() {
     const {
         elements,
         addElement,
+        removeElement,
         selectedElement,
         setSelectedElement
     } = useDesigner();
@@ -21,7 +22,7 @@ function Designer() {
     const droppable = useDroppable({
         id: "designer-drop-area",
         data: {
-            idDesignerDropArea: true,
+            isDesignerDropArea: true,
         }
     })
 
@@ -30,30 +31,102 @@ function Designer() {
             const { active, over } = event;
             if (!active || !over) return;
 
+            // The first case: dropping a sidebar element over the designer drop-zone-area
             const isDesignerBtnElement = active.data?.current?.isDesignerBtnElement;
+            const isDroppingOverDesignerDropArea = over.data?.current?.isDesignerDropArea;
 
-            if (isDesignerBtnElement) {
+            const droppingSidebarBtnOverDesignerDropArea =
+                isDesignerBtnElement &&
+                isDroppingOverDesignerDropArea;
+
+            if (droppingSidebarBtnOverDesignerDropArea) {
                 const type = active.data?.current?.type;
                 const newElement = FormElements[type as ElementsType].construct(
                     idGenerator()
                 )
 
-                addElement(0, newElement);
+                addElement(elements.length, newElement);
+                return;
             }
 
+            // The second case: dropping a sidebar element over the designer element
+            const isDroppingOverDesignerElementTopHalf = over.data?.current?.isTopHalfDesignerElement;
+            const isDroppingOverDesignerElementBottomHalf = over.data?.current?.isBottomHalfDesignerElement;
+
+            const isDroppingOverDesignerElement =
+                isDroppingOverDesignerElementTopHalf ||
+                isDroppingOverDesignerElementBottomHalf;
+
+            const droppingSidebarBtnOverDesignerElement =
+                isDesignerBtnElement &&
+                isDroppingOverDesignerElement;
+
+            if (droppingSidebarBtnOverDesignerElement) {
+                const type = active.data?.current?.type;
+                const newElement = FormElements[type as ElementsType].construct(
+                    idGenerator()
+                )
+
+                const overId = over.data?.current?.elementId;
+
+                const overElementIndex = elements.findIndex(el => el.id === overId);
+                if (overElementIndex === -1) {
+                    throw new Error("element not found");
+                }
+
+                let indexForNewElement = overElementIndex; // on top half
+                if (isDroppingOverDesignerElementBottomHalf) {
+                    // if not top half
+                    indexForNewElement = overElementIndex + 1;
+                }
+
+                addElement(indexForNewElement, newElement);
+                return;
+            }
+
+            // The third case: dropping the designer element over the designer element
+            const isDraggingDesignerElement = active.data?.current?.isDesignerElement;
+
+            const draggingDesignerElementOverDesignerElement =
+                isDroppingOverDesignerElement &&
+                isDraggingDesignerElement;
+
+            if (draggingDesignerElementOverDesignerElement) {
+                const activeId = active.data?.current?.elementId;
+                const overId = over.data?.current?.elementId;
+
+                const activeElementIndex = elements.findIndex(el => el.id === activeId);
+                const overElementIndex = elements.findIndex(el => el.id === overId);
+
+                if (activeElementIndex === -1 || overElementIndex === -1) {
+                    throw new Error("element not found");
+                }
+
+                const activeElement = { ...elements[activeElementIndex] };
+
+                removeElement(activeId);
+
+                let indexForNewElement = overElementIndex; // on top half
+                if (isDroppingOverDesignerElementBottomHalf) {
+                    // if not top half
+                    indexForNewElement = overElementIndex + 1;
+                }
+                addElement(indexForNewElement, activeElement);
+                return;
+            }
         },
     });
 
     return (
         <div className='flex w-full h-full'>
             <div className="p-4 w-full"
-            onClick={()=>{
-                if(selectedElement) setSelectedElement(null);
-            }}>
+                onClick={() => {
+                    if (selectedElement) setSelectedElement(null);
+                }}>
                 <div
                     ref={droppable.setNodeRef}
                     className={cn("bg-background max-w-[920px] h-full m-auto rounded-xl flex flex-col flex-grow items-center justify-start flex-1 overflow-y-auto",
-                        droppable.isOver && "ring-2 ring-primary/20"
+                        droppable.isOver && "ring-4 ring-primary ring-inset"
                     )}
                 >
                     {!droppable.isOver && elements.length === 0 && (


### PR DESCRIPTION
This PR introduces implementation of the drag and drop functionality for the FormBuilder component, which allows users to create and rearrange form elements on the canvas area. Three main scenarios are covered:

1. Dropping a sidebar element onto the designer drop-zone-area: This scenario occurs when a user drags an element from the sidebar and drops it onto the empty canvas area. The element is added to the end of the elements array.

2. Dropping a sidebar element over an existing designer element: This scenario occurs when a user drags an element from the sidebar and drops it over an existing element on the canvas. The new element is inserted either before or after the existing element, depending on whether the drop occurred on the top or bottom half of the existing element.

3. Dropping an existing designer element over another designer element: This scenario occurs when a user drags an existing element on the canvas and drops it over another existing element. The dragged element is removed from its current position and inserted either before or after the target element, again depending on whether the drop occurred on the top or bottom half of the target element.

The implementation uses the `useDndMonitor` hook from the `@dnd-kit/core` library to listen for drag and drop events and handle them accordingly. The `addElement` and `removeElement` functions from the `useDesigner` hook are used to add or remove elements from the elements array, while the `FormElements` object is used to construct new elements based on their type.