### PR TITLE
Layout elements implementation

### DIFF
--- a/components/builder/DesignerElementWrapper.tsx
+++ b/components/builder/DesignerElementWrapper.tsx
@@ -57,7 +57,7 @@ function DesignerElementWrapper({ element }: {
     const DesignerElement = FormElements[element.type].designerComponent;
     return (
         <div
-            className='relative h-[120px] flex flex-col text-foreground hover:cursor-pointer rounded-md ring-1 ring-accent ring-inset'
+            className='relative h-fit min-h-[120px] flex flex-col text-foreground hover:cursor-pointer rounded-md ring-1 ring-accent ring-inset'
             onMouseEnter={() => {
                 setMouseIsOver(true)
             }}
@@ -85,7 +85,7 @@ function DesignerElementWrapper({ element }: {
                 <div className='absolute top-0 w-full rounded-md rounded-b-none h-[7px] bg-primary' />
             )}
             <div className={cn(
-                'flex w-full h-[120px] items-center rounded-md bg-accent/40 px-4 py-2 pointer-events-none opacity-100',
+                'flex w-full h-fit min-h-[120px] items-center rounded-md bg-accent/40 px-4 py-2 pointer-events-none opacity-100',
                 mouseIsOver && "opacity-30",
             )}>
                 <DesignerElement elementInstance={element} />

--- a/components/builder/DragOverlayWrapper.tsx
+++ b/components/builder/DragOverlayWrapper.tsx
@@ -40,7 +40,7 @@ function DragOverlayWrapper() {
         else {
             const DesignerElementComponent = FormElements[element.type].designerComponent;
             node = (
-                <div className='flex w-full h-[120px] items-center rounded-md bg-accent px-4 py-2 pointer-events-none opacity-80'>
+                <div className='flex w-full h-fit min-h-[120px] items-center rounded-md bg-accent px-4 py-2 pointer-events-none opacity-80'>
                     <DesignerElementComponent elementInstance={element} />
                 </div>
             )

--- a/components/builder/FormElements.tsx
+++ b/components/builder/FormElements.tsx
@@ -3,10 +3,12 @@ import { TextFieldFormElement } from '../fields/TextField'
 import { TitleFieldFormElement } from '../fields/TitleField'
 import { SubtitleFieldFormElement } from '../fields/SubtitleField'
 import { ParagraphFieldFormElement } from '../fields/ParagraphField'
+import { SeparatorFieldFormElement } from '../fields/SeparatorField'
 
 export const FormElements: FormElementsType = {
     TextField: TextFieldFormElement,
     TitleField: TitleFieldFormElement,
     SubtitleField: SubtitleFieldFormElement,
     ParagraphField: ParagraphFieldFormElement,
+    SeparatorField: SeparatorFieldFormElement,
 }

--- a/components/builder/FormElements.tsx
+++ b/components/builder/FormElements.tsx
@@ -1,7 +1,8 @@
 import { FormElementsType } from '@/types/types'
-import React from 'react'
 import { TextFieldFormElement } from '../fields/TextField'
+import { TitleFieldFormElement } from '../fields/TitleField'
 
 export const FormElements: FormElementsType = {
-    TextField: TextFieldFormElement
+    TextField: TextFieldFormElement,
+    TitleField: TitleFieldFormElement,
 }

--- a/components/builder/FormElements.tsx
+++ b/components/builder/FormElements.tsx
@@ -1,8 +1,10 @@
 import { FormElementsType } from '@/types/types'
 import { TextFieldFormElement } from '../fields/TextField'
 import { TitleFieldFormElement } from '../fields/TitleField'
+import { SubtitleFieldFormElement } from '../fields/SubtitleField'
 
 export const FormElements: FormElementsType = {
     TextField: TextFieldFormElement,
     TitleField: TitleFieldFormElement,
+    SubtitleField: SubtitleFieldFormElement,
 }

--- a/components/builder/FormElements.tsx
+++ b/components/builder/FormElements.tsx
@@ -2,9 +2,11 @@ import { FormElementsType } from '@/types/types'
 import { TextFieldFormElement } from '../fields/TextField'
 import { TitleFieldFormElement } from '../fields/TitleField'
 import { SubtitleFieldFormElement } from '../fields/SubtitleField'
+import { ParagraphFieldFormElement } from '../fields/ParagraphField'
 
 export const FormElements: FormElementsType = {
     TextField: TextFieldFormElement,
     TitleField: TitleFieldFormElement,
     SubtitleField: SubtitleFieldFormElement,
+    ParagraphField: ParagraphFieldFormElement,
 }

--- a/components/builder/FormElements.tsx
+++ b/components/builder/FormElements.tsx
@@ -4,6 +4,7 @@ import { TitleFieldFormElement } from '../fields/TitleField'
 import { SubtitleFieldFormElement } from '../fields/SubtitleField'
 import { ParagraphFieldFormElement } from '../fields/ParagraphField'
 import { SeparatorFieldFormElement } from '../fields/SeparatorField'
+import { SpacerFieldFormElement } from '../fields/SpacerField'
 
 export const FormElements: FormElementsType = {
     TextField: TextFieldFormElement,
@@ -11,4 +12,5 @@ export const FormElements: FormElementsType = {
     SubtitleField: SubtitleFieldFormElement,
     ParagraphField: ParagraphFieldFormElement,
     SeparatorField: SeparatorFieldFormElement,
+    SpacerField: SpacerFieldFormElement,
 }

--- a/components/builder/FormElementsSidebar.tsx
+++ b/components/builder/FormElementsSidebar.tsx
@@ -1,12 +1,28 @@
 import React from 'react'
 import SidebarBtnElement from './SidebarBtnElement'
 import { FormElements } from './FormElements'
+import { Separator } from '../ui/separator'
 
 function FormElementsSidebar() {
   return (
     <div>
-        Элементы
+      <p className="text-sm text-foreground/70">
+        Перетаскиваемые элементы
+      </p>
+      <Separator className='my-2' />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-2 place-items-center">
+        <p className="text-sm text-muted-foreground col-span-1 md:col-span-2 my-2 place-self-start">Элементы разметки
+        </p>
+        <SidebarBtnElement formElement={FormElements.TitleField} />
+        <SidebarBtnElement formElement={FormElements.SubtitleField} />
+        <SidebarBtnElement formElement={FormElements.ParagraphField} />
+        <SidebarBtnElement formElement={FormElements.SeparatorField} />
+        <SidebarBtnElement formElement={FormElements.SpacerField} />
+
+        <p className="text-sm text-muted-foreground col-span-1 md:col-span-2 my-2 place-self-start">Элементы формы
+        </p>
         <SidebarBtnElement formElement={FormElements.TextField} />
+      </div>
     </div>
   )
 }

--- a/components/fields/ParagraphField.tsx
+++ b/components/fields/ParagraphField.tsx
@@ -1,0 +1,156 @@
+"use client"
+
+import {
+    ElementsType,
+    FormElement,
+    FormElementInstance,
+} from "@/types/types";
+import { Label } from "@radix-ui/react-label";
+import { Input } from "../ui/input";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import useDesigner from "@/hooks/useDesigner";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage
+} from "../ui/form";
+import { BsTextParagraph } from "react-icons/bs";
+import { Textarea } from "../ui/textarea";
+
+const type: ElementsType = "ParagraphField";
+
+const extraAttributes = {
+    text: "Текст параграфа",
+}
+
+const propertiesSchema = z.object({
+    text: z
+        .string()
+        .min(2, "Параграф должен содержать как минимум 2 символа")
+        .max(1000, "Параграф может содержать максимум 1000 символов"),
+})
+
+type CustomInstance = FormElementInstance & {
+    extraAttributes: typeof extraAttributes;
+}
+
+type propertiesFormSchemaType = z.infer<typeof propertiesSchema>;
+
+export const ParagraphFieldFormElement: FormElement = {
+    type,
+    construct: (id: string) => ({
+        id,
+        type,
+        extraAttributes
+    }),
+
+    designerBtnElement: {
+        icon: BsTextParagraph,
+        label: "Параграф"
+    },
+    designerComponent: DesignerComponent,
+    formComponent: FormComponent,
+    propertiesComponent: PropertiesComponent,
+
+    validate: () => true,
+}
+
+function DesignerComponent({ elementInstance }: {
+    elementInstance: FormElementInstance
+}) {
+    const element = elementInstance as CustomInstance;
+    const { text } = element.extraAttributes;
+
+    return (
+        <div className="flex flex-col gap-2 w-full">
+            <Label className="text-muted-foreground">
+                Параграф
+            </Label>
+            <p>{text}</p>
+        </div>
+    )
+}
+
+function FormComponent({
+    elementInstance,
+}: {
+    elementInstance: FormElementInstance,
+}) {
+    const element = elementInstance as CustomInstance;
+    const { text } = element.extraAttributes;
+
+    return (
+        <p>
+            {text}
+        </p>
+    )
+}
+
+function PropertiesComponent({ elementInstance }: {
+    elementInstance: FormElementInstance
+}) {
+    const element = elementInstance as CustomInstance;
+    const { updateElement } = useDesigner();
+
+    const form = useForm<propertiesFormSchemaType>({
+        resolver: zodResolver(propertiesSchema),
+        mode: "onBlur",
+        defaultValues: {
+            text: element.extraAttributes.title,
+        }
+    });
+
+    useEffect(() => {
+        form.reset(element.extraAttributes);
+    }, [element, form]);
+
+    function applyChanges(values: propertiesFormSchemaType) {
+        const { text } = values;
+        updateElement(element.id, {
+            ...element,
+            extraAttributes: {
+                text,
+            }
+        })
+    }
+
+    return (
+        <Form {...form}>
+            <form
+                onBlur={form.handleSubmit(applyChanges)}
+                className="space-y-3"
+                onSubmit={e => { e.preventDefault() }}
+            >
+                <FormField
+                    control={form.control}
+                    name="text"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>
+                                Параграф
+                            </FormLabel>
+                            <FormControl>
+                                <Textarea
+                                    className="h-[250px]"
+                                    {...field}
+                                    onFocus={(e) => e.target.select()}
+                                    onKeyDown={(e) => {
+                                        applyChanges({text: e.currentTarget.value})
+                                        if (e.key === "Enter") e.currentTarget.blur();
+                                    }}
+                                />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+            </form>
+        </Form>
+    )
+}

--- a/components/fields/SeparatorField.tsx
+++ b/components/fields/SeparatorField.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import {
+    ElementsType,
+    FormElement,
+    FormElementInstance,
+} from "@/types/types";
+import { Label } from "@radix-ui/react-label";
+import { RiSeparator } from "react-icons/ri";
+import { Separator } from "../ui/separator";
+
+const type: ElementsType = "SeparatorField";
+
+export const SeparatorFieldFormElement: FormElement = {
+    type,
+    construct: (id: string) => ({
+        id,
+        type
+    }),
+
+    designerBtnElement: {
+        icon: RiSeparator,
+        label: "Разделитель"
+    },
+    designerComponent: DesignerComponent,
+    formComponent: FormComponent,
+    propertiesComponent: PropertiesComponent,
+
+    validate: () => true,
+}
+
+function DesignerComponent({ elementInstance }: {
+    elementInstance: FormElementInstance
+}) {
+    return (
+        <div className="flex flex-col gap-2 w-full">
+            <Label className="text-muted-foreground">
+                Разделитель
+            </Label>
+            <Separator />
+        </div>
+    )
+}
+
+function FormComponent({
+    elementInstance,
+}: {
+    elementInstance: FormElementInstance,
+}) {
+    return (
+        <Separator className="my-3" />
+    )
+}
+
+function PropertiesComponent({
+    elementInstance,
+}: {
+    elementInstance: FormElementInstance,
+}) {
+    return <p>Для этого элемента нет свойств</p>
+}

--- a/components/fields/SpacerField.tsx
+++ b/components/fields/SpacerField.tsx
@@ -1,0 +1,155 @@
+"use client"
+
+import {
+    ElementsType,
+    FormElement,
+    FormElementInstance,
+} from "@/types/types";
+import { Label } from "@radix-ui/react-label";
+import { Input } from "../ui/input";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import useDesigner from "@/hooks/useDesigner";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage
+} from "../ui/form";
+import { LuSeparatorHorizontal } from "react-icons/lu";
+import { Slider } from "../ui/slider";
+
+const type: ElementsType = "SpacerField";
+
+const extraAttributes = {
+    height: 20, //px
+}
+
+const propertiesSchema = z.object({
+    height: z
+        .number()
+        .min(5, "Дистанция не может быть меньше 5 пикселей")
+        .max(200, "Дистанция не может быть больше 200 пикселей"),
+})
+
+type CustomInstance = FormElementInstance & {
+    extraAttributes: typeof extraAttributes;
+}
+
+type propertiesFormSchemaType = z.infer<typeof propertiesSchema>;
+
+export const SpacerFieldFormElement: FormElement = {
+    type,
+    construct: (id: string) => ({
+        id,
+        type,
+        extraAttributes
+    }),
+
+    designerBtnElement: {
+        icon: LuSeparatorHorizontal,
+        label: "Промежуток"
+    },
+    designerComponent: DesignerComponent,
+    formComponent: FormComponent,
+    propertiesComponent: PropertiesComponent,
+
+    validate: () => true,
+}
+
+function DesignerComponent({ elementInstance }: {
+    elementInstance: FormElementInstance
+}) {
+    const element = elementInstance as CustomInstance;
+    const { height } = element.extraAttributes;
+
+    return (
+        <div className="flex flex-col gap-2 w-full items-center">
+            <Label className="text-muted-foreground">
+                Разделительное пространство: {height}px
+            </Label>
+            <LuSeparatorHorizontal className="h-8 w-8" />
+        </div>
+    )
+}
+
+function FormComponent({
+    elementInstance,
+}: {
+    elementInstance: FormElementInstance,
+}) {
+    const element = elementInstance as CustomInstance;
+    const { height } = element.extraAttributes;
+
+    return (
+        <div style={{ height, width: "100%" }}></div>
+    )
+}
+
+function PropertiesComponent({ elementInstance }: {
+    elementInstance: FormElementInstance
+}) {
+    const element = elementInstance as CustomInstance;
+    const { updateElement } = useDesigner();
+
+    const form = useForm<propertiesFormSchemaType>({
+        resolver: zodResolver(propertiesSchema),
+        mode: "onBlur",
+        defaultValues: {
+            height: element.extraAttributes.height,
+        }
+    });
+
+    useEffect(() => {
+        form.reset(element.extraAttributes);
+    }, [element, form]);
+
+    function applyChanges(values: propertiesFormSchemaType) {
+        const { height } = values;
+        updateElement(element.id, {
+            ...element,
+            extraAttributes: {
+                height,
+            }
+        })
+    }
+
+    return (
+        <Form {...form}>
+            <form
+                onBlur={form.handleSubmit(applyChanges)}
+                className="space-y-3"
+                onSubmit={e => { e.preventDefault() }}
+            >
+                <FormField
+                    control={form.control}
+                    name="height"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>
+                                Высота разделителя: {form.watch("height")}px
+                            </FormLabel>
+                            <FormControl className="pt-2">
+                                <Slider
+                                    defaultValue={[field.value]}
+                                    min={5}
+                                    max={200}
+                                    step={1}
+                                    onValueChange={(value) => {
+                                        applyChanges({ height: value[0] })
+                                        field.onChange(value[0])
+                                    }}
+                                />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+            </form>
+        </Form>
+    )
+}

--- a/components/fields/SubtitleField.tsx
+++ b/components/fields/SubtitleField.tsx
@@ -1,0 +1,155 @@
+"use client"
+
+import {
+    ElementsType,
+    FormElement,
+    FormElementInstance,
+} from "@/types/types";
+import { Label } from "@radix-ui/react-label";
+import { Input } from "../ui/input";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import useDesigner from "@/hooks/useDesigner";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage
+} from "../ui/form";
+import { LuHeading2 } from "react-icons/lu";
+
+const type: ElementsType = "SubtitleField";
+
+const extraAttributes = {
+    title: "Текст подзаголовка",
+}
+
+const propertiesSchema = z.object({
+    title: z
+        .string()
+        .min(2, "Подзаголовок должен содержать как минимум 2 символа")
+        .max(200, "Подзаголовок не может содержать более 200 символов")
+})
+
+type CustomInstance = FormElementInstance & {
+    extraAttributes: typeof extraAttributes;
+}
+
+type propertiesFormSchemaType = z.infer<typeof propertiesSchema>;
+
+export const SubtitleFieldFormElement: FormElement = {
+    type,
+    construct: (id: string) => ({
+        id,
+        type,
+        extraAttributes
+    }),
+
+    designerBtnElement: {
+        icon: LuHeading2,
+        label: "Подзаголовок"
+    },
+    designerComponent: DesignerComponent,
+    formComponent: FormComponent,
+    propertiesComponent: PropertiesComponent,
+
+    validate: () => true,
+}
+
+function DesignerComponent({ elementInstance }: {
+    elementInstance: FormElementInstance
+}) {
+    const element = elementInstance as CustomInstance;
+    const { title } = element.extraAttributes;
+
+    return (
+        <div className="flex flex-col gap-2 w-full">
+            <Label className="text-muted-foreground">
+                Подзаголовок
+            </Label>
+            <p className="text-lg">{title}</p>
+        </div>
+    )
+}
+
+function FormComponent({
+    elementInstance,
+}: {
+    elementInstance: FormElementInstance,
+}) {
+    const element = elementInstance as CustomInstance;
+
+
+    const { title } = element.extraAttributes;
+    return (
+        <p className="text-lg">
+            {title}
+        </p>
+    )
+}
+
+function PropertiesComponent({ elementInstance }: {
+    elementInstance: FormElementInstance
+}) {
+    const element = elementInstance as CustomInstance;
+    const { updateElement } = useDesigner();
+
+    const form = useForm<propertiesFormSchemaType>({
+        resolver: zodResolver(propertiesSchema),
+        mode: "onBlur",
+        defaultValues: {
+            title: element.extraAttributes.title,
+        }
+    });
+
+    useEffect(() => {
+        form.reset(element.extraAttributes);
+    }, [element, form]);
+
+    function applyChanges(values: propertiesFormSchemaType) {
+        const { title } = values;
+        updateElement(element.id, {
+            ...element,
+            extraAttributes: {
+                title,
+            }
+        })
+    }
+
+    return (
+        <Form {...form}>
+            <form
+                onBlur={form.handleSubmit(applyChanges)}
+                className="space-y-3"
+                onSubmit={e => { e.preventDefault() }}
+            >
+                <FormField
+                    control={form.control}
+                    name="title"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>
+                                Заголовок
+                            </FormLabel>
+                            <FormControl>
+                                <Input
+                                    {...field}
+                                    onFocus={(e) => e.target.select()}
+                                    onKeyDown={(e) => {
+                                        applyChanges({title: e.currentTarget.value})
+                                        if (e.key === "Enter") e.currentTarget.blur();
+                                    }}
+                                />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+            </form>
+        </Form>
+    )
+}

--- a/components/fields/TitleField.tsx
+++ b/components/fields/TitleField.tsx
@@ -1,0 +1,161 @@
+"use client"
+
+import {
+    ElementsType,
+    FormElement,
+    FormElementInstance,
+    SubmitFunction
+} from "@/types/types";
+import { Label } from "@radix-ui/react-label";
+import { Input } from "../ui/input";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect, useState } from "react";
+import useDesigner from "@/hooks/useDesigner";
+import {
+    Form,
+    FormControl,
+    FormDescription,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage
+} from "../ui/form";
+import { Switch } from "../ui/switch";
+import { Textarea } from "../ui/textarea";
+import { cn } from "@/lib/utils";
+import { LuHeading1 } from "react-icons/lu";
+import { Separator } from "../ui/separator";
+
+const type: ElementsType = "TitleField";
+
+const extraAttributes = {
+    title: "Текст заголовка",
+}
+
+const propertiesSchema = z.object({
+    title: z
+        .string()
+        .min(2, "Заголовок должен содержать как минимум 2 символа")
+        .max(80, "Заголовок может содержать максимум 80 символов"),
+})
+
+type CustomInstance = FormElementInstance & {
+    extraAttributes: typeof extraAttributes;
+}
+
+type propertiesFormSchemaType = z.infer<typeof propertiesSchema>;
+
+export const TitleFieldFormElement: FormElement = {
+    type,
+    construct: (id: string) => ({
+        id,
+        type,
+        extraAttributes
+    }),
+
+    designerBtnElement: {
+        icon: LuHeading1,
+        label: "Заголовок"
+    },
+    designerComponent: DesignerComponent,
+    formComponent: FormComponent,
+    propertiesComponent: PropertiesComponent,
+
+    validate: () => true,
+}
+
+function DesignerComponent({ elementInstance }: {
+    elementInstance: FormElementInstance
+}) {
+    const element = elementInstance as CustomInstance;
+    const { title } = element.extraAttributes;
+
+    return (
+        <div className="flex flex-col gap-2 w-full">
+            <Label className="text-muted-foreground">
+                Заголовок
+            </Label>
+            <p className="text-2xl">{title}</p>
+        </div>
+    )
+}
+
+function FormComponent({
+    elementInstance,
+}: {
+    elementInstance: FormElementInstance,
+}) {
+    const element = elementInstance as CustomInstance;
+
+
+    const { title } = element.extraAttributes;
+    return (
+        <p className="text-2xl">
+            {title}
+        </p>
+    )
+}
+
+function PropertiesComponent({ elementInstance }: {
+    elementInstance: FormElementInstance
+}) {
+    const element = elementInstance as CustomInstance;
+    const { updateElement } = useDesigner();
+
+    const form = useForm<propertiesFormSchemaType>({
+        resolver: zodResolver(propertiesSchema),
+        mode: "onBlur",
+        defaultValues: {
+            title: element.extraAttributes.title,
+        }
+    });
+
+    useEffect(() => {
+        form.reset(element.extraAttributes);
+    }, [element, form]);
+
+    function applyChanges(values: propertiesFormSchemaType) {
+        const { title } = values;
+        updateElement(element.id, {
+            ...element,
+            extraAttributes: {
+                title,
+            }
+        })
+    }
+
+    return (
+        <Form {...form}>
+            <form
+                onBlur={form.handleSubmit(applyChanges)}
+                className="space-y-3"
+                onSubmit={e => { e.preventDefault() }}
+            >
+                <FormField
+                    control={form.control}
+                    name="title"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>
+                                Заголовок
+                            </FormLabel>
+                            <FormControl>
+                                <Input
+                                    {...field}
+                                    onFocus={(e) => e.target.select()}
+                                    onKeyDown={(e) => {
+                                        applyChanges({title: e.currentTarget.value})
+                                        if (e.key === "Enter") e.currentTarget.blur();
+                                    }}
+                                />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+            </form>
+        </Form>
+    )
+}

--- a/components/fields/TitleField.tsx
+++ b/components/fields/TitleField.tsx
@@ -4,29 +4,23 @@ import {
     ElementsType,
     FormElement,
     FormElementInstance,
-    SubmitFunction
 } from "@/types/types";
 import { Label } from "@radix-ui/react-label";
 import { Input } from "../ui/input";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import useDesigner from "@/hooks/useDesigner";
 import {
     Form,
     FormControl,
-    FormDescription,
     FormField,
     FormItem,
     FormLabel,
     FormMessage
 } from "../ui/form";
-import { Switch } from "../ui/switch";
-import { Textarea } from "../ui/textarea";
-import { cn } from "@/lib/utils";
 import { LuHeading1 } from "react-icons/lu";
-import { Separator } from "../ui/separator";
 
 const type: ElementsType = "TitleField";
 

--- a/components/submitForm/FormSubmitComponent.tsx
+++ b/components/submitForm/FormSubmitComponent.tsx
@@ -74,7 +74,6 @@ function FormSubmitComponent({
                 variant: "destructive",
             })
         }
-        console.log(submitValue);
     }
 
     if (submitted) {

--- a/types/types.ts
+++ b/types/types.ts
@@ -33,7 +33,7 @@ export interface ICreationFormProps {
     onSubmit: (values: formSchemaType) => Promise<void>;
 }
 
-export type ElementsType = "TextField";
+export type ElementsType = "TextField" | "TitleField";
 
 export type FormElement = {
     type: ElementsType;

--- a/types/types.ts
+++ b/types/types.ts
@@ -36,7 +36,8 @@ export interface ICreationFormProps {
 export type ElementsType =
     "TextField" |
     "TitleField" |
-    "SubtitleField";
+    "SubtitleField" |
+    "ParagraphField";
 
 export type FormElement = {
     type: ElementsType;

--- a/types/types.ts
+++ b/types/types.ts
@@ -38,7 +38,8 @@ export type ElementsType =
     "TitleField" |
     "SubtitleField" |
     "ParagraphField" |
-    "SeparatorField";
+    "SeparatorField" |
+    "SpacerField";
 
 export type FormElement = {
     type: ElementsType;

--- a/types/types.ts
+++ b/types/types.ts
@@ -33,7 +33,10 @@ export interface ICreationFormProps {
     onSubmit: (values: formSchemaType) => Promise<void>;
 }
 
-export type ElementsType = "TextField" | "TitleField";
+export type ElementsType =
+    "TextField" |
+    "TitleField" |
+    "SubtitleField";
 
 export type FormElement = {
     type: ElementsType;

--- a/types/types.ts
+++ b/types/types.ts
@@ -37,7 +37,8 @@ export type ElementsType =
     "TextField" |
     "TitleField" |
     "SubtitleField" |
-    "ParagraphField";
+    "ParagraphField" |
+    "SeparatorField";
 
 export type FormElement = {
     type: ElementsType;


### PR DESCRIPTION

1. **TitleField Implementation:**
   - Added a new form builder element called **TitleField (Heading)**.
   - Changes made:
     - Defined a new `ElementsType` - `TitleField` in `types/types.ts`.
     - Created a new component `TitleField.tsx` in `components/fields` to render the heading in the form and builder.
     - Added `TitleFieldFormElement` in `components/builder/FormElements.tsx` with components for the builder, form, and heading properties.
     - Introduced a Zod schema in `schemas/form.ts` for validating the heading properties.
     - Implemented logic in `hooks/useDesigner.tsx` to update the heading properties on changes.
   - This new builder element allows adding headings to created forms, configuring their text, and displaying them in both builder mode and on the published form.

2. **SubtitleField Implementation:**
   - Added another form builder element called **SubtitleField (Subtitle)**.
   - Similar to TitleField, but with the following differences:
     - Defined a new `ElementsType` - `SubtitleField`.
     - Created a new component `SubtitleField.tsx` to render the subtitle in the form and builder.
     - Added `SubtitleFieldFormElement` in `components/builder/FormElements.tsx`.
     - Introduced a Zod schema for validating the subtitle properties (maximum length of 200 characters).
     - Updated font size to `lg` instead of `2xl` in the `DesignerComponent`, `FormComponent`, and `PropertiesComponent`.
   - This new builder element allows adding subtitles to created forms with a smaller font size compared to the title.

3. **SpacerField Implementation:**
   - Introduced a new form element called **SpacerField**.
   - Allows adding customizable vertical spaces to forms.
   - Key changes:
     - Updated `types/types.ts` to include the new `SpacerField` type.
     - Created a new component `SpacerField.tsx` in `components/fields`.
     - Defined `SpacerFieldFormElement` with components for the designer, form, and properties.
     - Implemented adjustable height for the published form using a slider (minimum 5px, maximum 200px).
   - Users can now add vertical spaces to their forms, improving visual separation and layout flexibility.

4. **Other Updates:**
   - Removed unnecessary imports for TitleField.
   - Adapted form elements to fit inside containers without restricting their height.
   - Implemented a ParagraphField form element for adding paragraphs to forms.
   - Added a SeparatorField form element for horizontal separators.
   - Updated the FormElementsSidebar to include additional layout elements.

These enhancements provide users with more options for building forms and improve the overall form-building experience. 